### PR TITLE
Optimize build-workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,8 +8,6 @@
 name: Build
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 
@@ -58,7 +56,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Generate and submit dependency graph


### PR DESCRIPTION
- Trigger auf PRs beschränkt (vormals PRs & Pushs)
- Javaversion vom Dependency-Submission Job auf 21 angehoben (vormals 17)